### PR TITLE
Fix to support vc present

### DIFF
--- a/ios/RNCardVerify.m
+++ b/ios/RNCardVerify.m
@@ -73,10 +73,15 @@ RCT_EXPORT_METHOD(scan:(NSString * _Nullable)requiredIin requiredLastFour:(NSStr
 
     dispatch_async(dispatch_get_main_queue(), ^{
         if (@available(iOS 11.2, *)) {
-            UIViewController *rootViewController = UIApplication.sharedApplication.delegate.window.rootViewController;
-            UIViewController *vc = [Bouncer createVerifyViewControllerWithLast4:requiredLastFour iin:requiredIin withDelegate:self.verifyViewDelegate];
+            UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+
+            while (topController.presentedViewController) {
+                topController = topController.presentedViewController;
+            }
             
-            [rootViewController presentViewController:vc animated:NO completion:nil];
+            UIViewController *vc = [Bouncer createVerifyViewControllerWithLast4:requiredLastFour iin:requiredIin withDelegate:self.verifyViewDelegate];
+
+            [topController presentViewController:vc animated:NO completion:nil];
         } else {
             // Fallback on earlier versions
         }

--- a/ios/RNCardVerify.m
+++ b/ios/RNCardVerify.m
@@ -73,15 +73,15 @@ RCT_EXPORT_METHOD(scan:(NSString * _Nullable)requiredIin requiredLastFour:(NSStr
 
     dispatch_async(dispatch_get_main_queue(), ^{
         if (@available(iOS 11.2, *)) {
-            UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+            UIViewController *topViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
 
-            while (topController.presentedViewController) {
-                topController = topController.presentedViewController;
+            while (topViewController.presentedViewController) {
+                topViewController = topViewController.presentedViewController;
             }
             
             UIViewController *vc = [Bouncer createVerifyViewControllerWithLast4:requiredLastFour iin:requiredIin withDelegate:self.verifyViewDelegate];
 
-            [topController presentViewController:vc animated:NO completion:nil];
+            [topViewController presentViewController:vc animated:NO completion:nil];
         } else {
             // Fallback on earlier versions
         }


### PR DESCRIPTION
## Problem:

HolaCash is trying to present the CardVerify flow modally but something in our framework doesn't allow this. Specifically, the iOS error is

```swift
Warning: Attempt to present <CardVerify.VerifyCardSimpleViewController: 0x10895c200>  on <UIViewController: 0x108751c50> which is already presenting <RCTModalHostViewController: 0x121a41160>
```

and their view stack looks like this:

Root Main View | Modal View | Card Verify Scan View

## Solution & Explanation:

in our iOS wrapper file RNCardVerify.m , we tell the app to push the scan view on top of the root view in line 76 . 

```swift
UIViewController *rootViewController = UIApplication.sharedApplication.delegate.window.rootViewController;

UIViewController *vc = [Bouncer createVerifyViewControllerWithLast4:requiredLastFour iin:requiredIin withDelegate:self.verifyViewDelegate];

[rootViewController presentViewController:vc animated:NO completion:nil];
```

This causes an error with the example app provided to us by HolaCash since the root view is not the top of the view stack. 

The solution is to find the top most view and push the scan view onto the top view.