### PR TITLE
Ready call for iOS

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -65,7 +65,8 @@ export default () => {
   const [recentAction, setRecentAction] = useState('none');
 
   const downloadModels = useCallback(async () => {
-    CardVerify.downloadModels();
+      CardVerify.downloadModels();
+      alert(await CardVerify.awaitReady());
   }, []);
 
   const scanCard = useCallback(async () => {

--- a/ios/RNCardVerify.m
+++ b/ios/RNCardVerify.m
@@ -11,6 +11,8 @@
 @interface RCT_EXTERN_MODULE(RNCardVerify, NSObject)
 RCT_EXTERN_METHOD(isSupportedAsync:(RCTPromiseResolveBlock)resolve
                   :(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(awaitReady:(RCTPromiseResolveBlock)resolve
+                  :(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(scan:(NSString * _Nullable)requiredIin
                   :(NSString * _Nullable)requiredLastFour
                   :(BOOL)skipVerificationOnModelDownloadFailure

--- a/ios/RNCardVerify.swift
+++ b/ios/RNCardVerify.swift
@@ -22,7 +22,14 @@ class RNCardVerify: NSObject {
     @objc class func requiresMainQueueSetup() -> Bool {
         return true
     }
-    
+
+    @objc func awaitReady(
+        _ resolve: RCTPromiseResolveBlock,
+        _ reject: RCTPromiseRejectBlock
+    ) -> Void {
+        resolve([true])
+    }
+
     @objc func isSupportedAsync(
         _ resolve: RCTPromiseResolveBlock,
         _ reject: RCTPromiseRejectBlock


### PR DESCRIPTION
Simply returns true because we embed our main loop models in the SDK