### PR TITLE
Support multiple invocations of enter manually

### DIFF
--- a/ios/RNCardVerify.swift
+++ b/ios/RNCardVerify.swift
@@ -166,6 +166,8 @@ extension RNCardVerify: VerifyCardAddResult {
         if let resolve = resolve {
             resolve(["action": "skipped"])
         }
+
+        resolve = nil;
     }
     
     func fraudModelResultsVerifyCardAdd(viewController: UIViewController, creditCard: CreditCard, encryptedPayload: String?, extraData: [String: Any]) {

--- a/ios/RNCardVerify.swift
+++ b/ios/RNCardVerify.swift
@@ -167,7 +167,7 @@ extension RNCardVerify: VerifyCardAddResult {
             resolve(["action": "skipped"])
         }
 
-        resolve = nil;
+        resolve = nil
     }
     
     func fraudModelResultsVerifyCardAdd(viewController: UIViewController, creditCard: CreditCard, encryptedPayload: String?, extraData: [String: Any]) {


### PR DESCRIPTION
Enter card manually breaks when called multiple times in iOS. This resolves the crash.